### PR TITLE
Fix Kickstarter export: TagoRUN theme, analysis runtime, widget order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@tago-io/sdk": "^11.3.8",
+        "@tago-io/sdk": "^12.2.3",
         "async": "3.2.5",
-        "axios": "1.6.5",
         "lodash": "4.17.21",
         "luxon": "^3.4.4"
       },
@@ -1362,7 +1361,8 @@
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
-      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
+      "dev": true
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "5.0.1",
@@ -1433,35 +1433,20 @@
       }
     },
     "node_modules/@tago-io/sdk": {
-      "version": "11.3.8",
-      "resolved": "https://registry.npmjs.org/@tago-io/sdk/-/sdk-11.3.8.tgz",
-      "integrity": "sha512-Rs0DDCzbLBpMRuN7LAs4FtBnuXuYDjQYcaMxXcIGDHj3k8a+s+CBk1yQp2URvYDgXlvdnh2p5Mb52DTNn0zYxQ==",
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@tago-io/sdk/-/sdk-12.2.3.tgz",
+      "integrity": "sha512-ZHnCPQZAbjwy0T+4llpMdqUXwtn3YmfSNuG64zGKFE8M5jPj12hW9xhha8utoTaXd5xluqKgbCSHsckafzScog==",
       "license": "Apache-2.0",
       "dependencies": {
-        "axios": "1.7.4",
-        "form-data": "4.0.0",
-        "nanoid": "3.3.7",
-        "papaparse": "5.4.1",
-        "qs": "6.12.0",
-        "socket.io-client": "4.7.5"
+        "nanoid": "5.1.5",
+        "papaparse": "5.5.3",
+        "qs": "6.15.2"
       },
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=6.0.0"
+        "node": ">=20.0.0"
       },
       "optionalDependencies": {
-        "eventsource": "2.0.2"
-      }
-    },
-    "node_modules/@tago-io/sdk/node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "eventsource": "4.0.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -2482,11 +2467,6 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
       "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -2497,16 +2477,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
-      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
-      "dependencies": {
-        "follow-redirects": "^1.15.4",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -3018,17 +2988,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
@@ -3169,6 +3128,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -3284,14 +3244,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-newline": {
@@ -3417,6 +3369,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
       "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -3430,6 +3383,7 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
       "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -4404,13 +4358,26 @@
       }
     },
     "node_modules/eventsource": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
-      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.0.0.tgz",
+      "integrity": "sha512-fvIkb9qZzdMxgZrEQDyll+9oJsyaVvY92I2Re+qK0qEJ+w5s0X3dtz+M0VAPOjP1gtU3iqWyjQ0G3nvd5CLZ2g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "optional": true,
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {
@@ -4578,26 +4545,6 @@
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -4605,19 +4552,6 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/form-data-encoder": {
@@ -6415,25 +6349,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-      "dependencies": {
-        "mime-db": "1.51.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -6479,12 +6394,13 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
       "funding": [
         {
           "type": "github",
@@ -6493,10 +6409,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/natural-compare": {
@@ -6743,9 +6659,10 @@
       }
     },
     "node_modules/papaparse": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
-      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -6991,11 +6908,6 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7037,12 +6949,12 @@
       ]
     },
     "node_modules/qs": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.0.tgz",
-      "integrity": "sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -7527,6 +7439,7 @@
       "version": "4.7.5",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
       "integrity": "sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -7542,6 +7455,7 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
       "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "dev": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"
@@ -8489,6 +8403,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -8522,6 +8437,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
       "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -9626,7 +9542,8 @@
     "@socket.io/component-emitter": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
-      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
+      "dev": true
     },
     "@szmarczak/http-timer": {
       "version": "5.0.1",
@@ -9672,29 +9589,14 @@
       }
     },
     "@tago-io/sdk": {
-      "version": "11.3.8",
-      "resolved": "https://registry.npmjs.org/@tago-io/sdk/-/sdk-11.3.8.tgz",
-      "integrity": "sha512-Rs0DDCzbLBpMRuN7LAs4FtBnuXuYDjQYcaMxXcIGDHj3k8a+s+CBk1yQp2URvYDgXlvdnh2p5Mb52DTNn0zYxQ==",
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@tago-io/sdk/-/sdk-12.2.3.tgz",
+      "integrity": "sha512-ZHnCPQZAbjwy0T+4llpMdqUXwtn3YmfSNuG64zGKFE8M5jPj12hW9xhha8utoTaXd5xluqKgbCSHsckafzScog==",
       "requires": {
-        "axios": "1.7.4",
-        "eventsource": "2.0.2",
-        "form-data": "4.0.0",
-        "nanoid": "3.3.7",
-        "papaparse": "5.4.1",
-        "qs": "6.12.0",
-        "socket.io-client": "4.7.5"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "1.7.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-          "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-          "requires": {
-            "follow-redirects": "^1.15.6",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        }
+        "eventsource": "4.0.0",
+        "nanoid": "5.1.5",
+        "papaparse": "5.5.3",
+        "qs": "6.15.2"
       }
     },
     "@tsconfig/node10": {
@@ -10420,26 +10322,11 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
       "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
     "available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
-    },
-    "axios": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
-      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
-      "requires": {
-        "follow-redirects": "^1.15.4",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
     },
     "babel-jest": {
       "version": "29.7.0",
@@ -10800,14 +10687,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "commander": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
@@ -10924,6 +10803,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -10997,11 +10877,6 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -11095,6 +10970,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
       "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
+      "dev": true,
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
@@ -11106,7 +10982,8 @@
     "engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "dev": true
     },
     "enhanced-resolve": {
       "version": "5.12.0",
@@ -11715,9 +11592,18 @@
       "dev": true
     },
     "eventsource": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
-      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.0.0.tgz",
+      "integrity": "sha512-fvIkb9qZzdMxgZrEQDyll+9oJsyaVvY92I2Re+qK0qEJ+w5s0X3dtz+M0VAPOjP1gtU3iqWyjQ0G3nvd5CLZ2g==",
+      "optional": true,
+      "requires": {
+        "eventsource-parser": "^3.0.1"
+      }
+    },
+    "eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "optional": true
     },
     "execa": {
@@ -11855,11 +11741,6 @@
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
     },
-    "follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
-    },
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -11867,16 +11748,6 @@
       "dev": true,
       "requires": {
         "is-callable": "^1.1.3"
-      }
-    },
-    "form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
       }
     },
     "form-data-encoder": {
@@ -13170,19 +13041,6 @@
         "picomatch": "^2.3.1"
       }
     },
-    "mime-db": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
-    },
-    "mime-types": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-      "requires": {
-        "mime-db": "1.51.0"
-      }
-    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -13213,12 +13071,13 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -13391,9 +13250,9 @@
       }
     },
     "papaparse": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
-      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -13568,11 +13427,6 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true
     },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
     "punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -13595,11 +13449,11 @@
       "dev": true
     },
     "qs": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.0.tgz",
-      "integrity": "sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "requires": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       }
     },
     "queue-microtask": {
@@ -13920,6 +13774,7 @@
       "version": "4.7.5",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
       "integrity": "sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==",
+      "dev": true,
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
@@ -13931,6 +13786,7 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
       "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "dev": true,
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"
@@ -14584,6 +14440,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "dev": true,
       "requires": {}
     },
     "xdg-basedir": {
@@ -14595,7 +14452,8 @@
     "xmlhttprequest-ssl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
-      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A=="
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "build": "analysis-builder src/startAnalysis.ts build/analysis.tago.js"
   },
   "jest": {
-    "preset": "ts-jest"
+    "preset": "ts-jest",
+    "moduleNameMapper": {
+      "^nanoid$": "<rootDir>/test/nanoidMock.js"
+    }
   },
   "author": "",
   "license": "ISC",
@@ -47,9 +50,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@tago-io/sdk": "^11.3.8",
+    "@tago-io/sdk": "^12.2.3",
     "async": "3.2.5",
-    "axios": "1.6.5",
     "lodash": "4.17.21",
     "luxon": "^3.4.4"
   }

--- a/src/cleanAnalysis.ts
+++ b/src/cleanAnalysis.ts
@@ -1,6 +1,4 @@
-import { Account, Analysis, Utils } from "@tago-io/sdk";
-import { Data } from "@tago-io/sdk/out/common/common.types";
-import { TagoContext } from "@tago-io/sdk/out/modules/Analysis/analysis.types";
+import { Account, Analysis, Data, TagoContext, Utils } from "@tago-io/sdk";
 
 import { EntityType, IExport } from "./exportTypes";
 import auditLogSetup from "./lib/auditLogSetup";
@@ -76,7 +74,7 @@ async function startCleaner(context: TagoContext, scope: Data[]) {
         const device_list = await import_account.devices.list({ amount: 999, fields: ["id", "bucket"], filter: { tags: [{ key: config.export_tag }] } });
         auditlog(`Cleaning Devices: ${device_list.length} found.`);
         await Promise.all(device_list.map(({ id }) => import_account.devices.delete(id)));
-        await Promise.all(device_list.map(({ bucket }) => import_account.buckets.delete(bucket)));
+        await Promise.all(device_list.map(({ bucket }) => import_account.buckets.devices.delete(bucket)));
         break;
       case "dashboards":
         console.info("Cleaning Dashboards");

--- a/src/lib/data.logic.ts
+++ b/src/lib/data.logic.ts
@@ -3,7 +3,7 @@
 // * This file is all logics of parseit (example script).
 // ? ====================================================================================
 
-import { DataToSend } from "@tago-io/sdk/lib/types";
+import { DataToSend } from "@tago-io/sdk";
 
 interface GenericBody {
   [index: string]: any;

--- a/src/lib/filterExport.ts
+++ b/src/lib/filterExport.ts
@@ -1,4 +1,4 @@
-import { TagsObj } from "@tago-io/sdk/out/common/common.types";
+import { TagsObj } from "@tago-io/sdk";
 
 function filterExport(dashboard: { [key: string]: any }) {
   const export_tag = dashboard.tags.find((tag: TagsObj) => tag.key === "export_id");

--- a/src/services/analysisExport.ts
+++ b/src/services/analysisExport.ts
@@ -1,9 +1,13 @@
 import zlib from "zlib";
 import { Account } from "@tago-io/sdk";
-import axios from "axios";
 
 import { IExportHolder } from "../exportTypes";
 import replaceObj from "../lib/replaceObj";
+
+// The SDK still types runtime/language as the legacy "node" | "python", but the API accepts the
+// full set below. We propagate the source runtime as-is so a "deno-rt2025" analysis is not
+// recreated as legacy "node".
+type AnalysisRuntime = "node-legacy" | "python-legacy" | "node-rt2025" | "python-rt2025" | "deno-rt2025" | "node" | "python" | "other";
 
 async function analysisExport(account: Account, import_account: Account, export_holder: IExportHolder) {
   console.info("Exporting analysis: started");
@@ -19,24 +23,24 @@ async function analysisExport(account: Account, import_account: Account, export_
     let { id: target_id } = import_list.find((analysis) => analysis.tags?.find((tag) => tag.key === "export_id" && tag.value == export_id)) || { id: null };
 
     const new_analysis = replaceObj(analysis, { ...export_holder.devices, ...export_holder.tokens });
+    const runtime: AnalysisRuntime = (analysis as any).runtime ?? "node";
     if (!target_id) {
-      ({ id: target_id } = await import_account.analysis.create(new_analysis));
+      ({ id: target_id } = await import_account.analysis.create({ ...new_analysis, runtime } as any));
     } else {
       await import_account.analysis.edit(target_id, {
         name: new_analysis.name,
         tags: new_analysis.tags,
         active: new_analysis.active,
         variables: new_analysis.variables,
-      });
+        runtime,
+      } as any);
     }
     const script = await account.analysis.downloadScript(analysis_id);
-    const script_base64 = await axios
-      .get(script.url, {
-        responseType: "arraybuffer",
-      })
-      .then((response) => zlib.gunzipSync(response.data).toString("base64"));
+    const response = await fetch(script.url);
+    const arrayBuffer = await response.arrayBuffer();
+    const script_base64 = zlib.gunzipSync(Buffer.from(arrayBuffer)).toString("base64");
 
-    await import_account.analysis.uploadScript(target_id, { content: script_base64, language: "node", name: "script.js" });
+    await import_account.analysis.uploadScript(target_id, { content: script_base64, language: runtime, name: "script.js" } as any);
 
     export_holder.analysis[analysis_id] = target_id;
   }

--- a/src/services/collectIDs.ts
+++ b/src/services/collectIDs.ts
@@ -1,5 +1,4 @@
-import { Account, Utils } from "@tago-io/sdk";
-import { DeviceListItem } from "@tago-io/sdk/lib/types";
+import { Account, DeviceListItem, Utils } from "@tago-io/sdk";
 
 import { Entity, IExportHolder } from "../exportTypes";
 

--- a/src/services/createSecret.ts
+++ b/src/services/createSecret.ts
@@ -1,5 +1,4 @@
-import { Resources } from "@tago-io/sdk";
-import { Regions } from "@tago-io/sdk/lib/regions";
+import { Regions, Resources } from "@tago-io/sdk";
 
 async function createSecret(token: string, region: Regions) {
   const resource = new Resources({ token, region });
@@ -10,6 +9,7 @@ async function createSecret(token: string, region: Regions) {
   }
 
   await resource.secrets.create({ key: "ACCOUNT_TOKEN", value: token, tags: [{ key: "account_token", value: "true" }] });
+  await resource.secrets.create({ key: "SENDGRID_API_KEY", value: "<SENDGRID_API_KEY>", tags: [{ key: "sendgrid_credentials", value: "true" }] });
   return "Secret created";
 }
 

--- a/src/services/dashboardsExport.ts
+++ b/src/services/dashboardsExport.ts
@@ -1,7 +1,6 @@
 import { queue } from "async";
 
-import { Account } from "@tago-io/sdk";
-import { DashboardInfo } from "@tago-io/sdk/lib/types";
+import { Account, DashboardInfo } from "@tago-io/sdk";
 
 import { IExportHolder } from "../exportTypes";
 import { insertWidgets, removeAllWidgets } from "./widgetsExport";

--- a/src/services/dictionaryExport.ts
+++ b/src/services/dictionaryExport.ts
@@ -1,7 +1,6 @@
 import { queue } from "async";
 
-import { Account } from "@tago-io/sdk";
-import { DictionaryInfo } from "@tago-io/sdk/lib/types";
+import { Account, DictionaryInfo } from "@tago-io/sdk";
 
 import { IExportHolder } from "../exportTypes";
 

--- a/src/services/runButtonsExport.ts
+++ b/src/services/runButtonsExport.ts
@@ -1,5 +1,4 @@
-import { Account } from "@tago-io/sdk";
-import { RunInfo } from "@tago-io/sdk/lib/types";
+import { Account, RunInfo } from "@tago-io/sdk";
 
 import { IExportHolder } from "../exportTypes";
 import replaceObj from "../lib/replaceObj";
@@ -66,6 +65,7 @@ async function runButtonsExport(account: Account, import_account: Account, expor
     signin_buttons: targetRunInfo.signin_buttons,
     email_templates: targetRunInfo.email_templates,
     sidebar_buttons: targetRunInfo.sidebar_buttons,
+    theme: (runInfo as any).theme,
   };
 
   if (!targetRunInfo.dictionary) {

--- a/src/services/widgetsExport.test.ts
+++ b/src/services/widgetsExport.test.ts
@@ -1,0 +1,54 @@
+import { sortHiddenWidgetsFirst } from "./widgetsExport";
+
+describe("sortHiddenWidgetsFirst", () => {
+  const tabs = [
+    { key: "tab_visible", type: "" },
+    { key: "tab_hidden", type: "hidden" },
+  ];
+
+  test("places hidden-tab widgets before visible-tab widgets", () => {
+    const arrangement = [
+      { widget_id: "visible_a", tab: "tab_visible" },
+      { widget_id: "hidden_a", tab: "tab_hidden" },
+      { widget_id: "visible_b", tab: "tab_visible" },
+      { widget_id: "hidden_b", tab: "tab_hidden" },
+    ];
+
+    const sorted = sortHiddenWidgetsFirst(arrangement, tabs);
+
+    expect(sorted.map((x) => x.widget_id)).toEqual(["hidden_a", "hidden_b", "visible_a", "visible_b"]);
+  });
+
+  test("identifies hidden tabs by type === 'hidden' on a real dashboard arrangement", () => {
+    // Tab "zZoK_1AQCt-iQiI29Yl7e" has type "hidden"; its two widgets must be created first.
+    const realTabs = [
+      { key: "IujZ8pqDeqGR9wiAVYnqB", type: "", value: "#GLOBAL.OVERVIEW#" },
+      { key: "DWCnrWQFhX9Q7pFnLn_ct", type: "", value: "#GLOBAL.HELPER_EN_US#" },
+      { key: "lX97Kjts9qumnoOcA7G7Q", type: "", value: "#GLOBAL.HELPER_PT_BR#" },
+      { key: "zZoK_1AQCt-iQiI29Yl7e", type: "hidden", value: "#GLOBAL.HIDDEN#" },
+    ];
+    const realArrangement = [
+      { tab: "IujZ8pqDeqGR9wiAVYnqB", widget_id: "6a32b0f1d3f020000ca5c208" },
+      { tab: "DWCnrWQFhX9Q7pFnLn_ct", widget_id: "6a32b0f3d5cee5000c54b207" },
+      { tab: "lX97Kjts9qumnoOcA7G7Q", widget_id: "6a32b0f4c4325f000c7358cc" },
+      { tab: "zZoK_1AQCt-iQiI29Yl7e", widget_id: "6a32b0f2c4325f000c735866" },
+      { tab: "zZoK_1AQCt-iQiI29Yl7e", widget_id: "6a32b0f2bf4706000c01817b" },
+    ];
+
+    const sorted = sortHiddenWidgetsFirst(realArrangement, realTabs);
+
+    expect(sorted.slice(0, 2).map((x) => x.widget_id)).toEqual(["6a32b0f2c4325f000c735866", "6a32b0f2bf4706000c01817b"]);
+  });
+
+  test("does not mutate the original arrangement", () => {
+    const arrangement = [
+      { widget_id: "visible_a", tab: "tab_visible" },
+      { widget_id: "hidden_a", tab: "tab_hidden" },
+    ];
+    const original = [...arrangement];
+
+    sortHiddenWidgetsFirst(arrangement, tabs);
+
+    expect(arrangement).toEqual(original);
+  });
+});

--- a/src/services/widgetsExport.ts
+++ b/src/services/widgetsExport.ts
@@ -1,10 +1,21 @@
 import { queue } from "async";
 
-import { Account } from "@tago-io/sdk";
-import { DashboardInfo, WidgetInfo } from "@tago-io/sdk/lib/types";
+import { Account, DashboardInfo, WidgetInfo } from "@tago-io/sdk";
 
 import { IExportHolder } from "../exportTypes";
 import replaceObj from "../lib/replaceObj";
+
+/**
+ * Orders widgets so the ones in hidden tabs are created first. A header button on a visible widget
+ * references a hidden widget by id, and that reference is only remapped (via widget_holder) if the
+ * hidden widget already exists when the referencing widget is created. A tab is hidden when its
+ * `type` is "hidden".
+ */
+function sortHiddenWidgetsFirst(arrangement: any[], tabs: any[]) {
+  const hiddenTabs = new Set((tabs || []).filter((tab: any) => tab.type === "hidden").map((tab: any) => tab.key));
+  const isHidden = (item: any) => hiddenTabs.has(item.tab);
+  return [...arrangement].sort((a, b) => Number(isHidden(b)) - Number(isHidden(a)));
+}
 
 async function insertWidgets(account: Account, import_account: Account, dashboard: DashboardInfo, target: DashboardInfo, export_holder: IExportHolder) {
   const widget_ids = dashboard.arrangement?.map((x) => x.widget_id);
@@ -25,11 +36,10 @@ async function insertWidgets(account: Account, import_account: Account, dashboar
 
   await newWidgetQueue.drain();
 
-  const hidden_tabs = new Set(dashboard.tabs.filter((tab: any) => !tab.hidden).map((tab: any) => tab.key));
   if (!dashboard.arrangement) {
     return;
   }
-  const arrangement = dashboard.arrangement.sort((a) => (hidden_tabs.has(a.tab) ? 1 : -1));
+  const arrangement = sortHiddenWidgetsFirst(dashboard.arrangement, dashboard.tabs);
 
   const new_arrangement: any = [];
   const widget_holder: { [key: string]: string } = {};
@@ -77,4 +87,4 @@ async function removeAllWidgets(import_account: Account, dashboard: DashboardInf
   await widgetQueue.drain();
 }
 
-export { removeAllWidgets, insertWidgets };
+export { removeAllWidgets, insertWidgets, sortHiddenWidgetsFirst };

--- a/src/startAnalysis.ts
+++ b/src/startAnalysis.ts
@@ -1,7 +1,4 @@
-import axios from "axios";
-
-import { Account, Analysis, Utils } from "@tago-io/sdk";
-import { Data, TagoContext } from "@tago-io/sdk/lib/types";
+import { Account, Analysis, Data, TagoContext, Utils } from "@tago-io/sdk";
 
 import { EntityType, IExport, IExportHolder } from "./exportTypes";
 import auditLogSetup from "./lib/auditLogSetup";

--- a/test/nanoidMock.js
+++ b/test/nanoidMock.js
@@ -1,0 +1,6 @@
+// nanoid 5.x ships as ESM-only, which Jest (CommonJS) cannot require through the
+// @tago-io/sdk bundle. Tests never exercise id generation, so a deterministic stub is enough.
+module.exports = {
+  nanoid: () => "test-nanoid-id",
+  customAlphabet: () => () => "test-nanoid-id",
+};


### PR DESCRIPTION
## Summary
The Kickstarter (default) app was refactored and the export tool fell behind. This PR fixes three export defects and updates the libraries.

- TagoRUN theme colors were not copied: `run.edit` omitted the `theme` object, so only the sidebar was recreated on the target. Now the source theme is copied.
- Analysis runtime was not respected: analyses were recreated as legacy `node` because the edit path never sent `runtime` and `uploadScript` hardcoded `language` to `node`. The source runtime (`node-rt2025`, `deno-rt2025`, etc.) is now propagated to create, edit and uploadScript.
- Two widgets did not open their header button (e.g. "Create Organization"): header buttons reference widgets in hidden tabs by id, but the previous ordering checked `tab.hidden` (which does not exist; tabs use `type === "hidden"`) and used a one-argument comparator, so the order was unreliable. Hidden-tab widgets are now created first.

## Changes
- `fix(run-buttons)`: copy the TagoRUN `theme` from the source profile.
- `fix(analysis)`: preserve the source runtime on create/edit/uploadScript; replace the axios script download with native `fetch`.
- `fix(widgets)`: sort hidden-tab widgets first via `sortHiddenWidgetsFirst`, with unit tests.
- `chore(deps)`: upgrade `@tago-io/sdk` 11.3.8 to 12.2.3, drop `axios`, redirect SDK subpath imports to the package root, add a nanoid mock for Jest.

## Test plan
- [x] `npm run linter` clean
- [x] `npm test` (7 passing, including new `widgetsExport` tests)
- [x] `npm run build` compiles against SDK 12.2.3
- [x] End-to-end export run on the **Kickstarter default** application: TagoRUN theme applied, analyses created with the correct runtime, header-button widgets open the input form.
- [x] End-to-end export run on the **RTLS** application: same validation, all three fixes confirmed.

## Risk (CIA)
Likelihood: 🟢 Low | Impact: 🟢 Low | Exposure: 🟢 Low