### PR TITLE
Harden export token checks, remap analysis IDs, and seed the settings device

### DIFF
--- a/src/applications.ts
+++ b/src/applications.ts
@@ -1,0 +1,6 @@
+// Kickstarter application tokens used as the export source. Single source of truth shared by the
+// analysis entrypoint and the settings seed.
+export const applications = {
+  default: "19c43a65-dd50-49a7-9535-09038c2934d8",
+  rtls: "2a4889a4-7c89-4278-b2b9-6fcd30eabd6d",
+};

--- a/src/services/analysisExport.ts
+++ b/src/services/analysisExport.ts
@@ -15,34 +15,48 @@ async function analysisExport(account: Account, import_account: Account, export_
   const list = await account.analysis.list({ amount: 99, fields: ["id", "name", "tags"], filter: { tags: [{ key: "export_id" }] } }).then((r) => r.reverse());
   const import_list = await import_account.analysis.list({ amount: 99, fields: ["id", "tags"], filter: { tags: [{ key: "export_id" }] } });
 
+  // Pass 1: create/find every target analysis first so export_holder.analysis holds the full old->new ID
+  // map before any variables are written. This makes ID remapping order-independent, so env vars that
+  // reference another analysis ID (e.g. CRUD Alerts' alert_dispatcher_id) resolve to the new analysis.
+  const exportAnalysisList = [];
   for (const { id: analysis_id, name } of list) {
-    console.info(`Exporting analysis ${name}...`);
+    console.info(`Creating analysis ${name}...`);
     const analysis = await account.analysis.info(analysis_id);
     const export_id = analysis.tags?.find((tag) => tag.key === "export_id")?.value;
-
-    let { id: target_id } = import_list.find((analysis) => analysis.tags?.find((tag) => tag.key === "export_id" && tag.value == export_id)) || { id: null };
-
-    const new_analysis = replaceObj(analysis, { ...export_holder.devices, ...export_holder.tokens });
     const runtime: AnalysisRuntime = (analysis as any).runtime ?? "node";
+
+    let { id: target_id } = import_list.find((item) => item.tags?.find((tag) => tag.key === "export_id" && tag.value == export_id)) || { id: null };
     if (!target_id) {
-      ({ id: target_id } = await import_account.analysis.create({ ...new_analysis, runtime } as any));
-    } else {
-      await import_account.analysis.edit(target_id, {
-        name: new_analysis.name,
-        tags: new_analysis.tags,
-        active: new_analysis.active,
-        variables: new_analysis.variables,
-        runtime,
-      } as any);
+      ({ id: target_id } = await import_account.analysis.create({ name: analysis.name, tags: analysis.tags, runtime } as any));
     }
+
+    export_holder.analysis[analysis_id] = target_id;
+    exportAnalysisList.push({ analysis_id, analysis, target_id, runtime });
+  }
+
+  // Pass 2: with the complete ID map, remap references inside each analysis (devices, tokens, analysis IDs),
+  // then write its variables and upload its script.
+  for (const { analysis_id, analysis, target_id, runtime } of exportAnalysisList) {
+    console.info(`Exporting analysis ${analysis.name}...`);
+    const new_analysis = replaceObj(analysis, { ...export_holder.devices, ...export_holder.tokens, ...export_holder.analysis });
+
+    await import_account.analysis.edit(target_id, {
+      name: new_analysis.name,
+      tags: new_analysis.tags,
+      active: new_analysis.active,
+      variables: new_analysis.variables,
+      description: new_analysis.description,
+      run_on: new_analysis.run_on,
+      interval: new_analysis.interval,
+      runtime,
+    } as any);
+
     const script = await account.analysis.downloadScript(analysis_id);
     const response = await fetch(script.url);
     const arrayBuffer = await response.arrayBuffer();
     const script_base64 = zlib.gunzipSync(Buffer.from(arrayBuffer)).toString("base64");
 
     await import_account.analysis.uploadScript(target_id, { content: script_base64, language: runtime, name: "script.js" } as any);
-
-    export_holder.analysis[analysis_id] = target_id;
   }
 
   console.info("Exporting analysis: finished");

--- a/src/services/devicesExport.ts
+++ b/src/services/devicesExport.ts
@@ -2,8 +2,9 @@ import { Account, Device, Utils } from "@tago-io/sdk";
 
 import { IExport, IExportHolder } from "../exportTypes";
 import replaceObj from "../lib/replaceObj";
+import { isDefaultApp, isSettingsDevice, seedSettingsDevice } from "./settingsSeed";
 
-async function deviceExport(account: Account, import_account: Account, export_holder: IExportHolder, config: IExport) {
+async function deviceExport(account: Account, import_account: Account, export_holder: IExportHolder, config: IExport, region: "us-e1" | "eu-w1") {
   console.info("Exporting devices: started");
 
   const list = await account.devices.list({
@@ -34,7 +35,7 @@ async function deviceExport(account: Account, import_account: Account, export_ho
       ({ device_id: target_id, token: new_token } = await import_account.devices.create(new_device));
 
       if (config.data && config.data.length > 0) {
-        const device = new Device({ token: new_token, region: "us-e1" });
+        const device = new Device({ token: new_token, region } as any);
         const old_device = new Device({ token });
 
         const data = await old_device.getData({
@@ -44,6 +45,11 @@ async function deviceExport(account: Account, import_account: Account, export_ho
         if (data.length > 0) {
           device.sendData(data).catch(console.error);
         }
+      }
+
+      // Seed the default global-inactivity alert into the settings device of the Default Kickstarter.
+      if (isDefaultApp(config.export.token) && isSettingsDevice(device.tags)) {
+        await seedSettingsDevice(new_token, region).catch(console.error);
       }
     } else {
       await import_account.devices.edit(target_id, {

--- a/src/services/runButtonsExport.ts
+++ b/src/services/runButtonsExport.ts
@@ -60,8 +60,7 @@ async function runButtonsExport(account: Account, import_account: Account, expor
   }
 
   const fieldsToEdit: any = {
-    // @ts-expect-error SDK doesn't have custom fields property yet
-    custom_fields: targetRunInfo.custom_fields,
+    custom_fields: (runInfo as any).custom_fields,
     signin_buttons: targetRunInfo.signin_buttons,
     email_templates: targetRunInfo.email_templates,
     sidebar_buttons: targetRunInfo.sidebar_buttons,

--- a/src/services/settingsSeed.ts
+++ b/src/services/settingsSeed.ts
@@ -1,0 +1,57 @@
+import { Device } from "@tago-io/sdk";
+
+import { applications } from "../applications";
+
+/**
+ * Default global-inactivity alert seeded into a fresh settings device, so the
+ * Default Kickstarter ships with a working alert.
+ */
+const SETTINGS_SEED = [
+  {
+    variable: "alert_management_devices",
+    value: "all_sensors",
+    group: "global-inactivity",
+    metadata: { label: "All Sensors", sentValues: [{ label: "All Sensors", value: "all_sensors" }] },
+  },
+  {
+    variable: "global_alert_type",
+    value: "inactivity",
+    group: "global-inactivity",
+    metadata: { label: "Inactivity" },
+  },
+  {
+    variable: "global_alert_condition",
+    value: "checkin",
+    group: "global-inactivity",
+    metadata: { label: "Check-in" },
+  },
+  {
+    variable: "global_alert_value",
+    value: 1,
+    unit: "hour",
+    group: "global-inactivity",
+    metadata: { label: "1 hour" },
+  },
+  {
+    variable: "global_alert_scope",
+    value: "all",
+    group: "global-inactivity",
+    metadata: { label: "All organization users", sentValues: [{ label: "All organization users", value: "all" }] },
+  },
+  {
+    variable: "global_alert_message",
+    value: "A sensor stopped sending data for more than 1 hour.",
+    group: "global-inactivity",
+  },
+];
+
+const isDefaultApp = (export_token: string) => export_token === applications.default;
+
+const isSettingsDevice = (tags: { key: string; value: string }[]) => tags.some((tag) => tag.key === "device_type" && tag.value === "settings");
+
+async function seedSettingsDevice(token: string, region: string) {
+  const device = new Device({ token, region } as any);
+  await device.sendData(SETTINGS_SEED);
+}
+
+export { isDefaultApp, isSettingsDevice, seedSettingsDevice };

--- a/src/start.ts
+++ b/src/start.ts
@@ -40,7 +40,7 @@ async function startImport() {
   for (const entity of import_rule) {
     switch (entity) {
       case "devices":
-        export_holder = await deviceExport(account, import_account, export_holder, config);
+        export_holder = await deviceExport(account, import_account, export_holder, config, "us-e1");
         idCollection.push("devices");
         break;
       case "dashboards":

--- a/src/startAnalysis.ts
+++ b/src/startAnalysis.ts
@@ -1,5 +1,6 @@
 import { Account, Analysis, Data, TagoContext, Utils } from "@tago-io/sdk";
 
+import { applications } from "./applications";
 import { EntityType, IExport, IExportHolder } from "./exportTypes";
 import auditLogSetup from "./lib/auditLogSetup";
 import { initializeValidation } from "./lib/validation";
@@ -12,11 +13,6 @@ import dashboardExport from "./services/dashboardsExport";
 import { deviceExport } from "./services/devicesExport";
 import dictionaryExport from "./services/dictionaryExport";
 import { runButtonsExport } from "./services/runButtonsExport";
-
-const applications = {
-  default: "19c43a65-dd50-49a7-9535-09038c2934d8",
-  rtls: "2a4889a4-7c89-4278-b2b9-6fcd30eabd6d",
-};
 
 const config: IExport = {
   // Export tag with unique ID's. Without tag bellow, entity will not be copied or updated.
@@ -81,14 +77,10 @@ async function startImport(context: TagoContext, scope: Data[]): Promise<void> {
 
   if (!config.export.token) {
     return Promise.reject(await validate("Missing account application token field", "danger"));
-  } else if (config.export.token.length !== 36) {
-    return Promise.reject(await validate('Invalid "account application token".', "danger"));
   }
 
   if (!config.import.token) {
     return Promise.reject(await validate("Missing profile-token field", "danger"));
-  } else if (config.import.token.length !== 36) {
-    return Promise.reject(await validate("Profile token invalid. Please check your token and try again.", "danger"));
   }
 
   if (!region?.value) {
@@ -126,8 +118,11 @@ async function startImport(context: TagoContext, scope: Data[]): Promise<void> {
 
   console.log(import_rule);
 
-  const run = await import_account.run.info();
-  if (!run || !run.name) {
+  const run = await import_account.run.info().catch(() => null);
+  if (!run) {
+    return Promise.reject(await validate("Profile token invalid. Please check your token and try again.", "danger"));
+  }
+  if (!run.name) {
     return Promise.reject(
       await validate(
         `Your profile needs to have TagoRUN enabled. Visit this [link](https://tago.${region?.value}.io/run), click on \`Start Now\` and then save the change to enable your TagoRUN.`,
@@ -159,7 +154,7 @@ async function startImport(context: TagoContext, scope: Data[]): Promise<void> {
       try {
         switch (entity) {
           case "devices":
-            export_holder = await deviceExport(account, import_account, export_holder, config);
+            export_holder = await deviceExport(account, import_account, export_holder, config, region.value);
             idCollection.push("devices");
             break;
           case "dashboards":


### PR DESCRIPTION
## Summary
Fixes four issues in the Kickstarter export flow: token validation that broke
on the new `p-` prefixed token format, stale analysis ID references in env vars
after export, a missing default alert configuration on the settings device of
the Default Kickstarter, and TagoRUN `custom_fields` (Custom Settings for Users)
not being copied to the target profile.

## Why
The backend changed the token format to add a `p-` prefix, which changed its
length and tripped the old fixed-length check. Separately, `[TagoIO] - CRUD
Alerts` stores the `[TagoIO] - Alert Dispatch` analysis ID in an env var; the
export never remapped analysis IDs, so the Action it creates ended up with no
analysis selected. The Default Kickstarter also shipped without a working
global-inactivity alert. Finally, the RUN export read `custom_fields` from the
target profile and wrote it straight back (a no-op), so the source profile's
custom user fields were never carried over.

## Test plan
- [x] Export the Default Kickstarter with a `p-` prefixed import token; export proceeds past validation
- [x] After export, open `[TagoIO] - CRUD Alerts` in the target profile and confirm `alert_dispatcher_id` points to the new `[TagoIO] - Alert Dispatch` analysis
- [x] Confirm the Action created by CRUD Alerts has the analysis selected
- [x] Confirm the settings device (`device_type=settings`) in a freshly created Default profile carries the `global-inactivity` group data
- [x] Re-export into an existing profile and confirm the seed is not re-sent (create-only)
- [x] Export a non-Default application and confirm no seed is sent
- [x] After export, confirm the target profile's RUN Custom Settings for Users matches the source `custom_fields`

## Risk (CIA)
Likelihood: 🟢 Low | Impact: 🟢 Low | Exposure: 🟢 Low